### PR TITLE
RoundLost eljaras

### DIFF
--- a/blackjack.js
+++ b/blackjack.js
@@ -67,3 +67,16 @@ function Throw() {
     activeBet = 0;
     Doubling = false;
 }
+function RoundLost() {
+    alert("Elvesztette a kört, a tétje elveszett és új kártyákat kap. Lapjai: "+ jatekosKartyai+" ("+GetCardValue(jatekosKartyai)+")");
+    nyertOsszeg = nyertOsszeg - activeBet;
+    activeBet = 0;
+    if (rendOsszeg == 0 || rendOsszeg < 0) {
+        GameLost();
+    }
+    StartGame();
+    document.getElementById("ShowPlayerCards").innerHTML = "?, ? (Tegyen tétet a kör megkezdéséhez!)";
+    document.getElementById("ShowVDCards").innerHTML = VDKartyai[0] + ", ?";
+
+    doubling = false;
+}


### PR DESCRIPTION
A RoundLost függvény értesíti a játékost, hogy elvesztette a kört, visszaállítja a tétet és új kártyákat oszt neki, ellenőrzi, hogy van-e elég pénze folytatni a játékot, majd új kör kezdődik.